### PR TITLE
Fix Instagram link markup

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -133,7 +133,7 @@ export default function Navbar() {
         </div>
 
         <div className="space-x-4 flex flex-row items-center">
-          <a href={userData.socialLinks.instagram} x>
+          <a href={userData.socialLinks.instagram}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="16"


### PR DESCRIPTION
## Summary
- fix typo in Navbar to remove stray `x` from Instagram link

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888d89090548330b3027ffeb25b1bfa